### PR TITLE
Add Home Assistant support + all status bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To use the serial connection to the OTGW, use a config.json like the following:
         "username": null,
         "password": null,
         "qos": 0,
-        "pub_topic_namespace": "value/otgw",
-        "sub_topic_namespace": "set/otgw"
+        "pub_topic_namespace": "otgw/value",
+        "sub_topic_namespace": "otgw/set"
     }
 }
 ```
@@ -85,47 +85,47 @@ To install this script as a daemon, run the following commands (on a Debian-base
 ### Publish topics
 By default, the service publishes messages to the following MQTT topics:
 
-- value/otgw => _The status of the service_
-- value/otgw/master_slave_status
-- value/otgw/ch_enabled
-- value/otgw/dhw_enabled
-- value/otgw/cooling_enabled
-- value/otgw/control_setpoint
-- value/otgw/remote_override_setpoint
-- value/otgw/max_relative_modulation_level
-- value/otgw/room_setpoint
-- value/otgw/relative_modulation_level
-- value/otgw/ch_water_pressure
-- value/otgw/room_temperature
-- value/otgw/boiler_water_temperature
-- value/otgw/dhw_temperature
-- value/otgw/outside_temperature
-- value/otgw/return_water_temperature
-- value/otgw/dhw_setpoint
-- value/otgw/max_ch_water_setpoint
-- value/otgw/burner_starts
-- value/otgw/ch_pump_starts
-- value/otgw/dhw_pump_starts
-- value/otgw/dhw_burner_starts
-- value/otgw/burner_operation_hours
-- value/otgw/ch_pump_operation_hours
-- value/otgw/dhw_pump_valve_operation_hours
-- value/otgw/dhw_burner_operation_hours
+- otgw/value => _The status of the service_
+- otgw/value/master_slave_status
+- otgw/value/ch_enabled
+- otgw/value/dhw_enabled
+- otgw/value/cooling_enabled
+- otgw/value/control_setpoint
+- otgw/value/remote_override_setpoint
+- otgw/value/max_relative_modulation_level
+- otgw/value/room_setpoint
+- otgw/value/relative_modulation_level
+- otgw/value/ch_water_pressure
+- otgw/value/room_temperature
+- otgw/value/boiler_water_temperature
+- otgw/value/dhw_temperature
+- otgw/value/outside_temperature
+- otgw/value/return_water_temperature
+- otgw/value/dhw_setpoint
+- otgw/value/max_ch_water_setpoint
+- otgw/value/burner_starts
+- otgw/value/ch_pump_starts
+- otgw/value/dhw_pump_starts
+- otgw/value/dhw_burner_starts
+- otgw/value/burner_operation_hours
+- otgw/value/ch_pump_operation_hours
+- otgw/value/dhw_pump_valve_operation_hours
+- otgw/value/dhw_burner_operation_hours
 
-> If you've changed the pub_topic_namespace value in the configuration, replace `value/otgw` with your configured value.
+> If you've changed the pub_topic_namespace value in the configuration, replace `otgw/value` with your configured value.
 > __TODO:__ Add description of all topics
 
 ### Subscription topics
 By default, the service listens to messages from the following MQTT topics:
 
-- set/otgw/room_setpoint/temporary - TT - Float
-- set/otgw/room_setpoint/constant - TC - Float
-- set/otgw/outside_temperature - OT - Float
-- set/otgw/hot_water/enable - HW - Boolean
-- set/otgw/hot_water/temperature - SW - Float
-- set/otgw/central_heating/enable - CH - Boolean
-- set/central_heating/temperature - SH - Float
-- set/control_setpoint - CS - Float
-- set/max_modulation - MM - Integer 0-100
+- otgw/set/room_setpoint/temporary - TT - Float
+- otgw/set/room_setpoint/constant - TC - Float
+- otgw/set/outside_temperature - OT - Float
+- otgw/set/hot_water/enable - HW - Boolean
+- otgw/set/hot_water/temperature - SW - Float
+- otgw/set/central_heating/enable - CH - Boolean
+- otgw/set/central_heating/temperature - SH - Float
+- otgw/set/control_setpoint - CS - Float
+- otgw/set/max_modulation - MM - Integer 0-100
 
 > __TODO:__ Add description of all topics

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ To install this script as a daemon, run the following commands (on a Debian-base
 By default, the service publishes messages to the following MQTT topics:
 
 - value/otgw => _The status of the service_
-- value/otgw/flame_status
-- value/otgw/flame_status_ch
-- value/otgw/flame_status_dhw
-- value/otgw/flame_status_bit
+- value/otgw/master_status
+- value/otgw/ch_enabled
+- value/otgw/dhw_enabled
+- value/otgw/cooling_enabled
 - value/otgw/control_setpoint
 - value/otgw/remote_override_setpoint
 - value/otgw/max_relative_modulation_level

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To install this script as a daemon, run the following commands (on a Debian-base
 By default, the service publishes messages to the following MQTT topics:
 
 - value/otgw => _The status of the service_
-- value/otgw/master_status
+- value/otgw/master_slave_status
 - value/otgw/ch_enabled
 - value/otgw/dhw_enabled
 - value/otgw/cooling_enabled

--- a/__main__.py
+++ b/__main__.py
@@ -210,7 +210,7 @@ def send_HA_discovery(publish_ha_config_only: bool = False):
                 topic=entity['topic'],
                 payload=entity['payload'],
                 qos=settings['mqtt']['qos'],
-                retain=False)
+                retain=True)
 
 
 def is_float(value):

--- a/__main__.py
+++ b/__main__.py
@@ -31,7 +31,8 @@ settings = {
         "pub_topic_namespace": "value/otgw",
         "sub_topic_namespace": "set/otgw",
         "retain": False,
-        "changed_messages_only": False
+        "changed_messages_only": False,
+        "homeassistant": None
     }
 }
 
@@ -220,6 +221,9 @@ otgw_type = {
                               .OTGWTcpClient,
                                   # This is actually not implemented yet
 }[settings['otgw']['type']]()
+
+if settings['mqtt']['homeassistant'] or True:
+    settings['ha_publish'] = send_HA_discovery
 
 # Create the actual instance of the client
 otgw_client = otgw_type(on_otgw_message, **settings['otgw'])

--- a/__main__.py
+++ b/__main__.py
@@ -168,11 +168,12 @@ def on_otgw_message(message):
         retain=retain)
 
 def send_HA_discovery():
-    if args.verbose:
-        log.debug("send HA discovery ")
 
-    for entity in opentherm.build_ha_config_data():
+    for entity in opentherm.build_ha_config_data(settings):
         # Send out messages to the MQTT broker
+        if args.verbose:
+            log.info("send HA discovery: {} ".format(entity))
+
         mqtt_client.publish(
             topic=entity['topic'],
             payload=entity['payload'],

--- a/__main__.py
+++ b/__main__.py
@@ -162,6 +162,18 @@ def on_otgw_message(message):
         qos=settings['mqtt']['qos'],
         retain=retain)
 
+def send_HA_discovery(data):
+    if args.verbose:
+        log.debug("send HA discovery: %s", payload)
+
+    for entity in data:
+        # Send out messages to the MQTT broker
+        mqtt_client.publish(
+            topic=entity['topic'],
+            payload=entity['payload'],
+            qos=settings['mqtt']['qos'],
+            retain=False)
+
 def is_float(value):
     try:
         float(value)

--- a/__main__.py
+++ b/__main__.py
@@ -96,6 +96,10 @@ def on_mqtt_connect(client, userdata, flags, rc):
         qos=settings['mqtt']['qos'],
         retain=True)
 
+    # if we're using HA, send the HA discovery messages
+    if settings['mqtt']['homeassistant']:
+        send_HA_discovery()
+
 def on_mqtt_message(client, userdata, msg):
     # Handle incoming messages
     log.info("Received message on topic {} with payload {}".format(
@@ -162,11 +166,11 @@ def on_otgw_message(message):
         qos=settings['mqtt']['qos'],
         retain=retain)
 
-def send_HA_discovery(data):
+def send_HA_discovery():
     if args.verbose:
-        log.debug("send HA discovery: %s", payload)
+        log.debug("send HA discovery ")
 
-    for entity in data:
+    for entity in opentherm.build_ha_config_data():
         # Send out messages to the MQTT broker
         mqtt_client.publish(
             topic=entity['topic'],
@@ -233,9 +237,6 @@ otgw_type = {
                               .OTGWTcpClient,
                                   # This is actually not implemented yet
 }[settings['otgw']['type']]()
-
-if settings['mqtt']['homeassistant'] or True:
-    settings['ha_publish'] = send_HA_discovery
 
 # Create the actual instance of the client
 otgw_client = otgw_type(on_otgw_message, **settings['otgw'])

--- a/__main__.py
+++ b/__main__.py
@@ -134,7 +134,10 @@ def on_mqtt_message(client, userdata, msg):
 
 def on_otgw_message(message):
     if args.verbose:
-        log.debug("%s %s", str(datetime.datetime.now()), message)
+        log.debug("message: [type: %s] %s", type(message), message)
+    if type(message) is not tuple:
+        log.error("interal malformed message received - message was probably incorrectly parsed")
+        return
     # Force retain for device state
     if message[0] == opentherm.topic_namespace and (message[1] == 'online' or message[1] == 'offline'):
         retain=True

--- a/__main__.py
+++ b/__main__.py
@@ -72,7 +72,8 @@ with open(args.config) as f:
         settings['mqtt'].update(overrides['mqtt'])
 
 # Set the namespace of the mqtt messages from the settings
-opentherm.topic_namespace=settings['mqtt']['pub_topic_namespace']
+opentherm.pub_topic_namespace=settings['mqtt']['pub_topic_namespace']
+opentherm.sub_topic_namespace=settings['mqtt']['sub_topic_namespace']
 
 # Set up logging
 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -91,7 +92,7 @@ def on_mqtt_connect(client, userdata, flags, rc):
     mqtt_client.subscribe('{}/#'.format(settings['mqtt']['sub_topic_namespace']))
     mqtt_client.subscribe('{}'.format(settings['mqtt']['sub_topic_namespace']))
     mqtt_client.publish(
-        topic=opentherm.topic_namespace,
+        topic=opentherm.pub_topic_namespace,
         payload="online",
         qos=settings['mqtt']['qos'],
         retain=True)
@@ -144,7 +145,7 @@ def on_otgw_message(message):
         log.error("interal malformed message received - message was probably incorrectly parsed")
         return
     # Force retain for device state
-    if message[0] == opentherm.topic_namespace and (message[1] == 'online' or message[1] == 'offline'):
+    if message[0] == opentherm.pub_topic_namespace and (message[1] == 'online' or message[1] == 'offline'):
         retain=True
     else:
         retain=settings['mqtt']['retain']
@@ -210,7 +211,7 @@ if settings['mqtt']['username']:
 # The will makes sure the device registers as offline when the connection
 # is lost
 mqtt_client.will_set(
-    topic=opentherm.topic_namespace,
+    topic=opentherm.pub_topic_namespace,
     payload="offline",
     qos=settings['mqtt']['qos'],
     retain=True)

--- a/config.json
+++ b/config.json
@@ -14,8 +14,8 @@
         "username": null,
         "password": null,
         "qos": 0,
-        "pub_topic_namespace": "value/otgw",
-        "sub_topic_namespace": "set/otgw",
+        "pub_topic_namespace": "otgw/value",
+        "sub_topic_namespace": "otgw/set",
         "retain": false
     }
 }

--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
         "qos": 0,
         "pub_topic_namespace": "otgw/value",
         "sub_topic_namespace": "otgw/set",
-        "retain": false
+        "retain": false,
+        "changed_messages_only": false,
+        "homeassistant": true
     }
 }

--- a/opentherm.py
+++ b/opentherm.py
@@ -165,6 +165,53 @@ payload_sensor = {
     "unit_of_measurement": None,
     "value_template": None,
 }
+# deepcopy
+payload_climate = copy.deepcopy(payload_sensor)
+payload_climate = {**payload_climate, 
+    **{
+    "action_template": None,
+    "action_topic": None,
+    "aux_command_topic": None,
+    "aux_state_template": None,
+    "aux_state_topic": None,
+    "away_mode_command_topic": None,
+    "away_mode_state_template": None,
+    "away_mode_state_topic": None,
+    "current_temperature_topic": pub_topic_namespace+'room_temperature/temperature',
+    "current_temperature_template": None,
+    "current_temperature_topic": None,
+    "initial": None,
+    "max_temp": None,
+    "min_temp": None,
+    "mode_command_topic": None,
+    "mode_state_template": "{% if value == '1' %}heat{% else %}off{% endif %}",
+    "mode_state_topic": pub_topic_namespace+'flame_status_ch/state',
+    "modes": ['off', 'heat'],
+    "precision": "0.5",
+    "retain": None,
+    # using temporary allows local thermostat override. use /constant to block
+    # room thermostat input
+    "temperature_command_topic": sub_topic_namespace+'room_setpoint/temporary',
+    "temperature_state_template": None,
+    "temperature_state_topic": pub_topic_namespace+'room_setpoint/setpoint',
+    "temperature_unit": None,
+    "temp_step": "0.5", 
+    "availability":
+        {
+        "payload_available": None,
+        "payload_not_available": None,
+        "topic": None,
+        },
+    "payload_off": 0,
+    "payload_on": 1,
+    }
+}
+del payload_climate["expire_after"]
+del payload_climate["force_update"]
+del payload_climate["icon"]
+del payload_climate["state_topic"]
+del payload_climate["unit_of_measurement"]
+payload_climate['name'] = "Thermostat"
 
 # deepcopy
 payload_binary_sensor = copy.deepcopy(payload_sensor)

--- a/opentherm.py
+++ b/opentherm.py
@@ -34,13 +34,39 @@ def flags_msg_generator(ot_id, val):
     Returns a generator for the messages
     """
     yield ("{}/{}".format(pub_topic_namespace, ot_id), val, )
-    if(ot_id == "master_status"):
+    if(ot_id == "master_slave_status"):
         yield ("{}/ch_enabled/state".format(pub_topic_namespace),
                int(val & ( 1 << 1 ) > 0), )
         yield ("{}/dhw_enabled/state".format(pub_topic_namespace),
                int(val & ( 1 << 2 ) > 0), )
         yield ("{}/cooling_enabled/state".format(pub_topic_namespace),
                int(val & ( 1 << 3 ) > 0), )
+        yield ("{}/otc_active/state".format(pub_topic_namespace),
+               int(val & ( 1 << 4 ) > 0), )
+        yield ("{}/ch2_enabled/state".format(pub_topic_namespace),
+               int(val & ( 1 << 5 ) > 0), )
+        yield ("{}/bit_5/state".format(pub_topic_namespace),
+               int(val & ( 1 << 6 ) > 0), )
+        yield ("{}/bit_6/state".format(pub_topic_namespace),
+               int(val & ( 1 << 7 ) > 0), )
+        yield ("{}/bit_7/state".format(pub_topic_namespace),
+               int(val & ( 1 << 8 ) > 0), )
+        yield ("{}/fault/state".format(pub_topic_namespace),
+               int(val & ( 1 << 9 ) > 0), )
+        yield ("{}/ch_active/state".format(pub_topic_namespace),
+               int(val & ( 1 << 10 ) > 0), )
+        yield ("{}/dhw_active/state".format(pub_topic_namespace),
+               int(val & ( 1 << 11 ) > 0), )
+        yield ("{}/flame_on/state".format(pub_topic_namespace),
+               int(val & ( 1 << 12 ) > 0), )
+        yield ("{}/cooling_active/state".format(pub_topic_namespace),
+               int(val & ( 1 << 13 ) > 0), )
+        yield ("{}/ch2_active/state".format(pub_topic_namespace),
+               int(val & ( 1 << 14 ) > 0), )
+        yield ("{}/diagnostic_indication/state".format(pub_topic_namespace),
+               int(val & ( 1 << 15 ) > 0), )
+        yield ("{}/bit_15/state".format(pub_topic_namespace),
+               int(val & ( 1 << 16 ) > 0), )
 
 def float_msg_generator(ot_id, val):
     r"""
@@ -98,7 +124,7 @@ def get_messages(message):
 # referenced generators have to be assigned first
 opentherm_ids = {
     # flame status is special case... multiple bits of data. see flags_msg_generator
-	0:   ("master_status",flags_msg_generator,),
+	0:   ("master_slave_status",flags_msg_generator,),
 	1:   ("control_setpoint/setpoint",float_msg_generator,),
 	9:   ("remote_override_setpoint/setpoint",float_msg_generator,),
 	14:  ("max_relative_modulation_level/level",float_msg_generator,),
@@ -120,9 +146,22 @@ opentherm_ids = {
 	121: ("ch_pump_operation_hours/hours",int_msg_generator,),
 	122: ("dhw_pump_valve_operation_hours/hours",int_msg_generator,),
 	123: ("dhw_burner_operation_hours/hours",int_msg_generator,),
-    997: ("ch_enabled/state",int_msg_generator,),
-    998: ("dhw_enabled/state",int_msg_generator,),
-    999: ("cooling_enabled/state",int_msg_generator,)
+    900: ("ch_enabled/state",int_msg_generator,),
+    901: ("dhw_enabled/state",int_msg_generator,),
+    902: ("cooling_enabled/state",int_msg_generator,),
+    903: ("otc_active/state",int_msg_generator,),
+    904: ("ch2_enabled/state",int_msg_generator,),
+    905: ("bit_5/state",int_msg_generator,),
+    906: ("bit_6/state",int_msg_generator,),
+    907: ("bit_7/state",int_msg_generator,),
+    908: ("fault/state",int_msg_generator,),
+    909: ("ch_active/state",int_msg_generator,),
+    910: ("dhw_active/state",int_msg_generator,),
+    911: ("flame_on/state",int_msg_generator,),
+    912: ("cooling_active/state",int_msg_generator,),
+    913: ("ch2_active/state",int_msg_generator,),
+    914: ("diagnostic_indication/state",int_msg_generator,),
+    915: ("bit_15/state",int_msg_generator,),
 }
 
 

--- a/opentherm.py
+++ b/opentherm.py
@@ -119,6 +119,75 @@ opentherm_ids = {
 	123: ("dhw_burner_operation_hours/hours",int_msg_generator,)
 }
 
+payload_sensor = {
+    "availability_topic": None,
+    "device":
+        {
+        "connections": None,
+        "identifiers": ["opentherm-gateway", "otgw"],
+        "manufacturer": "Schelte Bron",
+        "model": "otgw-nodo",
+        "name": "OpenTherm Gateway",
+        "sw_version": None,
+        "via_device": None
+        },
+    "device_class": None,
+    "expire_after": None,
+    "force_update": True,
+    "icon": None,
+    "json_attributes_template": None,
+    "json_attributes_topic": None,
+    "name": None,
+    "payload_available": None,
+    "payload_not_available": None,
+    "qos": None,
+    "state_topic": None,
+    "unique_id": None,
+    "unit_of_measurement": None,
+    "value_template": None,
+}
+
+# deepcopy
+payload_binary_sensor = {key: value[:] for key, value in payload_sensor.items()}
+payload_binary_sensor.append(
+    {
+    "availability":
+        {
+        "payload_available": None,
+        "payload_not_available": None,
+        "topic": None,
+        },
+    "off_delay": 0,
+    "payload_off": None,
+    "payload_on": None,
+    })
+del payload_binary_sensor["unit_of_measurement"]
+
+# deepcopy
+payload_sensor_temperature = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_temperature['device_class'] = 'temperature'
+payload_sensor_temperature['unit_of_measurement'] = 'C'
+
+payload_sensor_hours = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_hours['device_class'] = 'None'
+payload_sensor_hours['icon'] = 'has:clock'
+payload_sensor_hours['unit_of_measurement'] = 'Hours'
+
+payload_sensor_bar = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_bar['device_class'] = 'pressure'
+payload_sensor_bar['unit_of_measurement'] = 'Bar'
+
+
+payload_sensor_count = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_count['device_class'] = 'None'
+payload_sensor_count['unit_of_measurement'] = 'x'
+
+payload_sensor_level = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_level['device_class'] = 'None'
+payload_sensor_level['icon'] = 'mdi-percent'
+payload_sensor_level['unit_of_measurement'] = '%'
+
+
 class OTGWClient(object):
     r"""
     An abstract OTGW client.

--- a/opentherm.py
+++ b/opentherm.py
@@ -3,12 +3,14 @@ from threading import Thread
 from time import sleep
 import logging
 import collections
+import copy
 
 log = logging.getLogger(__name__)
 
 # Default namespace for the topics. Will be overwritten with the value in
 # config
 topic_namespace="value/otgw"
+ha_publish_namespace="homeassistant/"
 
 # Parse hex string to int
 def hex_int(hex):
@@ -148,9 +150,9 @@ payload_sensor = {
 }
 
 # deepcopy
-payload_binary_sensor = {key: value[:] for key, value in payload_sensor.items()}
-payload_binary_sensor.append(
-    {
+payload_binary_sensor = copy.deepcopy(payload_sensor)
+payload_binary_sensor = {**payload_binary_sensor, 
+    **{
     "availability":
         {
         "payload_available": None,
@@ -160,29 +162,30 @@ payload_binary_sensor.append(
     "off_delay": 0,
     "payload_off": None,
     "payload_on": None,
-    })
+    }
+}
 del payload_binary_sensor["unit_of_measurement"]
 
 # deepcopy
-payload_sensor_temperature = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_temperature = copy.deepcopy(payload_sensor)
 payload_sensor_temperature['device_class'] = 'temperature'
 payload_sensor_temperature['unit_of_measurement'] = 'C'
 
-payload_sensor_hours = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_hours = copy.deepcopy(payload_sensor)
 payload_sensor_hours['device_class'] = 'None'
 payload_sensor_hours['icon'] = 'has:clock'
 payload_sensor_hours['unit_of_measurement'] = 'Hours'
 
-payload_sensor_bar = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_bar = copy.deepcopy(payload_sensor)
 payload_sensor_bar['device_class'] = 'pressure'
 payload_sensor_bar['unit_of_measurement'] = 'Bar'
 
 
-payload_sensor_count = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_count = copy.deepcopy(payload_sensor)
 payload_sensor_count['device_class'] = 'None'
 payload_sensor_count['unit_of_measurement'] = 'x'
 
-payload_sensor_level = {key: value[:] for key, value in payload_sensor.items()}
+payload_sensor_level = copy.deepcopy(payload_sensor)
 payload_sensor_level['device_class'] = 'None'
 payload_sensor_level['icon'] = 'mdi-percent'
 payload_sensor_level['unit_of_measurement'] = '%'

--- a/opentherm.py
+++ b/opentherm.py
@@ -287,7 +287,7 @@ def build_ha_config_data (config):
         "count": {'ha_type': 'sensor', 'payload': payload_sensor_count},
         "level": {'ha_type': 'sensor', 'payload': payload_sensor_level},
         "state": {'ha_type': 'binary_sensor', 'payload': payload_binary_sensor},
-        "pressure": {'ha_type': 'pressure', 'payload': payload_sensor_pressure},
+        "pressure": {'ha_type': 'sensor', 'payload': payload_sensor_pressure},
     }
 
 
@@ -332,7 +332,7 @@ def build_ha_config_data (config):
         publish_topic = "{}/{}/{}/{}/config".format(ha_publish_namespace, ha_type, payload['unique_id'], name)
         payload = cleanNullTerms(payload)
         payload = json.dumps(payload)
-        data.append( {'topic': publish_topic, 'payload': payload})
+        data.append( {'topic': publish_topic, 'payload': payload, 'retain':'True'})
 
     return data
 

--- a/opentherm.py
+++ b/opentherm.py
@@ -9,7 +9,8 @@ log = logging.getLogger(__name__)
 
 # Default namespace for the topics. Will be overwritten with the value in
 # config
-topic_namespace="otgw/value"
+pub_topic_namespace="otgw/value"
+sub_topic_namespace="otgw/set"
 ha_publish_namespace="homeassistant"
 
 # Parse hex string to int
@@ -32,13 +33,13 @@ def flags_msg_generator(ot_id, val):
 
     Returns a generator for the messages
     """
-    yield ("{}/{}".format(topic_namespace, ot_id), val, )
+    yield ("{}/{}".format(pub_topic_namespace, ot_id), val, )
     if(ot_id == "flame_status"):
-        yield ("{}/flame_status_ch/state".format(topic_namespace),
+        yield ("{}/flame_status_ch/state".format(pub_topic_namespace),
                int(val & ( 1 << 1 ) > 0), )
-        yield ("{}/flame_status_dhw/state".format(topic_namespace),
+        yield ("{}/flame_status_dhw/state".format(pub_topic_namespace),
                int(val & ( 1 << 2 ) > 0), )
-        yield ("{}/flame_status_bit/state".format(topic_namespace),
+        yield ("{}/flame_status_bit/state".format(pub_topic_namespace),
                int(val & ( 1 << 3 ) > 0), )
 
 def float_msg_generator(ot_id, val):
@@ -47,7 +48,7 @@ def float_msg_generator(ot_id, val):
 
     Returns a generator for the messages
     """
-    yield ("{}/{}".format(topic_namespace, ot_id), round(val/float(256), 2), )
+    yield ("{}/{}".format(pub_topic_namespace, ot_id), round(val/float(256), 2), )
 
 def int_msg_generator(ot_id, val):
     r"""
@@ -55,7 +56,7 @@ def int_msg_generator(ot_id, val):
 
     Returns a generator for the messages
     """
-    yield ("{}/{}".format(topic_namespace, ot_id), val, )
+    yield ("{}/{}".format(pub_topic_namespace, ot_id), val, )
 
 def other_msg_generator(source, ttype, res, did, data):
     r"""
@@ -64,7 +65,7 @@ def other_msg_generator(source, ttype, res, did, data):
 
     Returns a generator for the messages
     """
-    yield ("{}/{}/{}/{}/{}/{}".format(topic_namespace, 'unknown', source, ttype, res, did), str(data), )
+    yield ("{}/{}/{}/{}/{}/{}".format(pub_topic_namespace, 'unknown', source, ttype, res, did), str(data), )
 
 def get_messages(message):
     r"""
@@ -138,7 +139,7 @@ def cleanNullTerms(d):
     return clean
 
 payload_sensor = {
-    "availability_topic": topic_namespace,
+    "availability_topic": pub_topic_namespace,
     "device":
         {
         "connections": None,
@@ -234,7 +235,7 @@ def build_ha_config_data ():
         payload['name'] = name
         # need to add the mqtt client name here to make it truely unique
         payload['unique_id'] = "{}_{}".format('otgw', name)
-        payload['state_topic'] = "{}/{}".format(topic_namespace, full_name)
+        payload['state_topic'] = "{}/{}".format(pub_topic_namespace, full_name)
         payload = cleanNullTerms(payload)
         payload = json.dumps(payload)
         publish_topic = "{}/{}/{}/config".format(ha_publish_namespace, ha_type, name)
@@ -344,10 +345,10 @@ class OTGWClient(object):
         while self._worker_running:
             try:
                 self.open()
-                self._listener((topic_namespace, 'online'))
+                self._listener((pub_topic_namespace, 'online'))
                 break
             except Exception:
-                self._listener((topic_namespace, 'offline'))
+                self._listener((pub_topic_namespace, 'offline'))
                 log.warning("Waiting %d seconds before retrying", reconnect_pause)
                 sleep(reconnect_pause)
 

--- a/opentherm.py
+++ b/opentherm.py
@@ -31,12 +31,12 @@ def flags_msg_generator(ot_id, val):
     Returns a generator for the messages
     """
     yield ("{}/{}".format(topic_namespace, ot_id), val, )
-    if(ot_id == "flame_status"):
-        yield ("{}/flame_status_ch".format(topic_namespace),
+    if(ot_id == "flame_status/state"):
+        yield ("{}/flame_status_ch/state".format(topic_namespace),
                val & ( 1 << 1 ) > 0, )
-        yield ("{}/flame_status_dhw".format(topic_namespace),
+        yield ("{}/flame_status_dhw/state".format(topic_namespace),
                val & ( 1 << 2 ) > 0, )
-        yield ("{}/flame_status_bit".format(topic_namespace),
+        yield ("{}/flame_status_bit/state".format(topic_namespace),
                val & ( 1 << 3 ) > 0, )
 
 def float_msg_generator(ot_id, val):
@@ -83,28 +83,28 @@ def get_messages(message):
 # discriptive names and message creators. I put this here because the
 # referenced generators have to be assigned first
 opentherm_ids = {
-	0:   ("flame_status",flags_msg_generator,),
-	1:   ("control_setpoint",float_msg_generator,),
-	9:   ("remote_override_setpoint",float_msg_generator,),
-	14:  ("max_relative_modulation_level",float_msg_generator,),
-	16:  ("room_setpoint",float_msg_generator,),
-	17:  ("relative_modulation_level",float_msg_generator,),
-	18:  ("ch_water_pressure",float_msg_generator,),
-	24:  ("room_temperature",float_msg_generator,),
-	25:  ("boiler_water_temperature",float_msg_generator,),
-	26:  ("dhw_temperature",float_msg_generator,),
-	27:  ("outside_temperature",float_msg_generator,),
-	28:  ("return_water_temperature",float_msg_generator,),
-	56:  ("dhw_setpoint",float_msg_generator,),
-	57:  ("max_ch_water_setpoint",float_msg_generator,),
-	116: ("burner_starts",int_msg_generator,),
-	117: ("ch_pump_starts",int_msg_generator,),
-	118: ("dhw_pump_starts",int_msg_generator,),
-	119: ("dhw_burner_starts",int_msg_generator,),
-	120: ("burner_operation_hours",int_msg_generator,),
-	121: ("ch_pump_operation_hours",int_msg_generator,),
-	122: ("dhw_pump_valve_operation_hours",int_msg_generator,),
-	123: ("dhw_burner_operation_hours",int_msg_generator,)
+	0:   ("flame_status/state",flags_msg_generator,),
+	1:   ("control_setpoint/setpoint",float_msg_generator,),
+	9:   ("remote_override_setpoint/setpoint",float_msg_generator,),
+	14:  ("max_relative_modulation_level/level",float_msg_generator,),
+	16:  ("room_setpoint/setpoint",float_msg_generator,),
+	17:  ("relative_modulation_level/level",float_msg_generator,),
+	18:  ("ch_water_pressure/pressure",float_msg_generator,),
+	24:  ("room_temperature/temperature",float_msg_generator,),
+	25:  ("boiler_water_temperature/temperature",float_msg_generator,),
+	26:  ("dhw_temperature/temperature",float_msg_generator,),
+	27:  ("outside_temperature/temperature",float_msg_generator,),
+	28:  ("return_water_temperature/temperature",float_msg_generator,),
+	56:  ("dhw_setpoint/setpoint",float_msg_generator,),
+	57:  ("max_ch_water_setpoint/setpoint",float_msg_generator,),
+	116: ("burner_starts/count",int_msg_generator,),
+	117: ("ch_pump_starts/count",int_msg_generator,),
+	118: ("dhw_pump_starts/count",int_msg_generator,),
+	119: ("dhw_burner_starts/count",int_msg_generator,),
+	120: ("burner_operation_hours/hours",int_msg_generator,),
+	121: ("ch_pump_operation_hours/hours",int_msg_generator,),
+	122: ("dhw_pump_valve_operation_hours/hours",int_msg_generator,),
+	123: ("dhw_burner_operation_hours/hours",int_msg_generator,)
 }
 
 class OTGWClient(object):

--- a/opentherm.py
+++ b/opentherm.py
@@ -138,136 +138,150 @@ def cleanNullTerms(d):
             clean[k] = v
     return clean
 
-payload_sensor = {
-    "availability_topic": pub_topic_namespace,
-    "device":
-        {
-        "connections": None,
-        "identifiers": ["opentherm-gateway"],
-        "manufacturer": "Schelte Bron",
-        "model": "otgw-nodo",
-        "name": "OpenTherm Gateway",
-        "sw_version": None,
-        "via_device": None
-        },
-    "device_class": None,
-    "expire_after": None,
-    "force_update": 'True',
-    "icon": None,
-    "json_attributes_template": None,
-    "json_attributes_topic": None,
-    "name": None,
-    "payload_available": None,
-    "payload_not_available": None,
-    "qos": None,
-    "state_topic": None,
-    "unique_id": None,
-    "unit_of_measurement": None,
-    "value_template": None,
-}
-# deepcopy
-payload_climate = copy.deepcopy(payload_sensor)
-payload_climate = {**payload_climate, 
-    **{
-    "action_template": None,
-    "action_topic": None,
-    "aux_command_topic": None,
-    "aux_state_template": None,
-    "aux_state_topic": None,
-    "away_mode_command_topic": None,
-    "away_mode_state_template": None,
-    "away_mode_state_topic": None,
-    "current_temperature_topic": pub_topic_namespace+'room_temperature/temperature',
-    "current_temperature_template": None,
-    "current_temperature_topic": None,
-    "initial": None,
-    "max_temp": None,
-    "min_temp": None,
-    "mode_command_topic": None,
-    "mode_state_template": "{% if value == '1' %}heat{% else %}off{% endif %}",
-    "mode_state_topic": pub_topic_namespace+'flame_status_ch/state',
-    "modes": ['off', 'heat'],
-    "precision": "0.5",
-    "retain": None,
-    # using temporary allows local thermostat override. use /constant to block
-    # room thermostat input
-    "temperature_command_topic": sub_topic_namespace+'room_setpoint/temporary',
-    "temperature_state_template": None,
-    "temperature_state_topic": pub_topic_namespace+'room_setpoint/setpoint',
-    "temperature_unit": None,
-    "temp_step": "0.5", 
-    "availability":
-        {
+
+def build_ha_config_data (config):
+    payload_sensor = {
+        "availability_topic": pub_topic_namespace,
+        "device":
+            {
+            "connections": None,
+            "identifiers": ["opentherm-gateway"],
+            "manufacturer": "Schelte Bron",
+            "model": "otgw-nodo",
+            "name": "OpenTherm Gateway",
+            "sw_version": None,
+            "via_device": None
+            },
+        "device_class": None,
+        "expire_after": None,
+        "force_update": 'True',
+        "icon": None,
+        "json_attributes_template": None,
+        "json_attributes_topic": None,
+        "name": None,
         "payload_available": None,
         "payload_not_available": None,
-        "topic": None,
-        },
-    "payload_off": 0,
-    "payload_on": 1,
+        "qos": None,
+        "state_topic": None,
+        "unique_id": None,
+        "unit_of_measurement": None,
+        "value_template": None,
     }
-}
-del payload_climate["expire_after"]
-del payload_climate["force_update"]
-del payload_climate["icon"]
-del payload_climate["state_topic"]
-del payload_climate["unit_of_measurement"]
-payload_climate['name'] = "Thermostat"
-
-# deepcopy
-payload_binary_sensor = copy.deepcopy(payload_sensor)
-payload_binary_sensor = {**payload_binary_sensor, 
-    **{
-    "availability":
-        {
-        "payload_available": None,
-        "payload_not_available": None,
-        "topic": None,
-        },
-    "off_delay": None,
-    "payload_off": 0,
-    "payload_on": 1,
+    # deepcopy
+    payload_climate = copy.deepcopy(payload_sensor)
+    payload_climate = {**payload_climate, 
+        **{
+        # "action_template": None,
+        # "action_topic": None,
+        # "aux_command_topic": None,
+        # "aux_state_template": None,
+        # "aux_state_topic": None,
+        # "away_mode_command_topic": None,
+        # "away_mode_state_template": None,
+        # "away_mode_state_topic": None,
+        "current_temperature_topic": pub_topic_namespace+'/room_temperature/temperature',
+        "current_temperature_template": None,
+        "initial": '18',
+        "max_temp": '24',
+        "min_temp": '16',
+        # "mode_command_topic": None,
+        "mode_state_template": "{% if value == '1' %}heat{% else %}off{% endif %}",
+        "mode_state_topic": pub_topic_namespace+'/flame_status_ch/state',
+        "modes": ['off', 'heat'],
+        "precision": 0.1,
+        "retain": None,
+        "send_if_off": None,
+        # using temporary allows local thermostat override. use /constant to block
+        # room thermostat input
+        "temperature_command_topic": sub_topic_namespace+'/room_setpoint/temporary',
+        "temperature_state_template": None,
+        "temperature_state_topic": pub_topic_namespace+'/room_setpoint/setpoint',
+        "temperature_unit": "C",
+        "temp_step": "0.5", 
+        "availability":
+            {
+            "payload_available": None,
+            "payload_not_available": None,
+            "topic": None,
+            },
+        "payload_off": 0,
+        "payload_on": 1,
+        }
     }
-}
-del payload_binary_sensor["unit_of_measurement"]
-payload_binary_sensor['device_class'] = 'heat'
+    del payload_climate["expire_after"]
+    del payload_climate["force_update"]
+    del payload_climate["icon"]
+    del payload_climate["state_topic"]
+    del payload_climate["unit_of_measurement"]
 
-# deepcopy
-payload_sensor_temperature = copy.deepcopy(payload_sensor)
-payload_sensor_temperature['device_class'] = 'temperature'
-payload_sensor_temperature['unit_of_measurement'] = 'C'
+    # deepcopy
+    payload_binary_sensor = copy.deepcopy(payload_sensor)
+    payload_binary_sensor = {**payload_binary_sensor, 
+        **{
+        "availability":
+            {
+            "payload_available": None,
+            "payload_not_available": None,
+            "topic": None,
+            },
+        "off_delay": None,
+        "payload_off": 0,
+        "payload_on": 1,
+        }
+    }
+    del payload_binary_sensor["unit_of_measurement"]
+    payload_binary_sensor['device_class'] = 'heat'
 
-payload_sensor_hours = copy.deepcopy(payload_sensor)
-payload_sensor_hours['device_class'] = None
-payload_sensor_hours['icon'] = 'mdi:clock'
-payload_sensor_hours['unit_of_measurement'] = 'Hours'
+    # deepcopy
+    payload_sensor_temperature = copy.deepcopy(payload_sensor)
+    payload_sensor_temperature['device_class'] = 'temperature'
+    payload_sensor_temperature['unit_of_measurement'] = 'C'
 
-payload_sensor_pressure = copy.deepcopy(payload_sensor)
-payload_sensor_pressure['device_class'] = 'pressure'
-payload_sensor_pressure['unit_of_measurement'] = 'Bar'
+    payload_sensor_hours = copy.deepcopy(payload_sensor)
+    payload_sensor_hours['device_class'] = None
+    payload_sensor_hours['icon'] = 'mdi:clock'
+    payload_sensor_hours['unit_of_measurement'] = 'Hours'
+
+    payload_sensor_pressure = copy.deepcopy(payload_sensor)
+    payload_sensor_pressure['device_class'] = 'pressure'
+    payload_sensor_pressure['unit_of_measurement'] = 'Bar'
 
 
-payload_sensor_count = copy.deepcopy(payload_sensor)
-payload_sensor_count['device_class'] = None
-payload_sensor_count['icon'] = 'mdi:counter'
-payload_sensor_count['unit_of_measurement'] = 'x'
+    payload_sensor_count = copy.deepcopy(payload_sensor)
+    payload_sensor_count['device_class'] = None
+    payload_sensor_count['icon'] = 'mdi:counter'
+    payload_sensor_count['unit_of_measurement'] = 'x'
 
-payload_sensor_level = copy.deepcopy(payload_sensor)
-payload_sensor_level['device_class'] = None
-payload_sensor_level['icon'] = 'mdi:percent'
-payload_sensor_level['unit_of_measurement'] = '%'
+    payload_sensor_level = copy.deepcopy(payload_sensor)
+    payload_sensor_level['device_class'] = None
+    payload_sensor_level['icon'] = 'mdi:percent'
+    payload_sensor_level['unit_of_measurement'] = '%'
 
-payload_mapping = {
-    "setpoint": {'ha_type': 'sensor', 'payload': payload_sensor_temperature},
-    "temperature": {'ha_type': 'sensor', 'payload': payload_sensor_temperature},
-    "hours": {'ha_type': 'sensor', 'payload': payload_sensor_hours},
-    "count": {'ha_type': 'sensor', 'payload': payload_sensor_count},
-    "level": {'ha_type': 'sensor', 'payload': payload_sensor_level},
-    "state": {'ha_type': 'binary_sensor', 'payload': payload_binary_sensor},
-    "pressure": {'ha_type': 'pressure', 'payload': payload_sensor_pressure},
-}
+    payload_mapping = {
+        "setpoint": {'ha_type': 'sensor', 'payload': payload_sensor_temperature},
+        "temperature": {'ha_type': 'sensor', 'payload': payload_sensor_temperature},
+        "hours": {'ha_type': 'sensor', 'payload': payload_sensor_hours},
+        "count": {'ha_type': 'sensor', 'payload': payload_sensor_count},
+        "level": {'ha_type': 'sensor', 'payload': payload_sensor_level},
+        "state": {'ha_type': 'binary_sensor', 'payload': payload_binary_sensor},
+        "pressure": {'ha_type': 'pressure', 'payload': payload_sensor_pressure},
+    }
 
-def build_ha_config_data ():
+
+    #########
+    #########
+    #########
+
     data = []
+
+    # data.append( {'topic': "{}/climate/thermostat/config".format(ha_publish_namespace), 'payload': ''})
+    # add thermostat entity
+    payload_climate['name'] = "{}_Thermostat".format(config['mqtt']['client_id'])
+    payload_climate['unique_id'] = "{}_thermostat".format(config['mqtt']['client_id'])
+    data.append( {'topic': "{}/climate/thermostat/config".format(ha_publish_namespace), 'payload': json.dumps(cleanNullTerms(payload_climate)) })
+
+    # todo: setpoint entities for the water temp setpoints
+
     for entity in opentherm_ids:
         
         full_name = opentherm_ids[entity][0]
@@ -279,9 +293,9 @@ def build_ha_config_data ():
         ha_type = payload_mapping[otgw_type]['ha_type']
         payload = copy.deepcopy(payload_mapping[otgw_type]['payload'])
 
-        payload['name'] = name
+        payload['name'] = "{}_{}".format(config['mqtt']['client_id'],name)
         # need to add the mqtt client name here to make it truely unique
-        payload['unique_id'] = "{}_{}".format('otgw', name)
+        payload['unique_id'] = "{}_{}".format(config['mqtt']['client_id'],name)
         payload['state_topic'] = "{}/{}".format(pub_topic_namespace, full_name)
         payload = cleanNullTerms(payload)
         payload = json.dumps(payload)


### PR DESCRIPTION
- Refactored topic usage
- converted boolean states to binary
- implemented Home Assistant discovery to automatically add device and entity to Home Assistant. 
- added support for multiple OTGW with 1 Home Assistant instance by using the 'client_id' config param as unique id
- added config switch for Home Assistant discovery
- added all status bits for slave